### PR TITLE
Enforce CLI has a output directory path that's not '.'

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
 
-const oclif = require('@oclif/core')
+const oclif = require("@oclif/core");
 
-oclif.run().then(require('@oclif/core/flush')).catch(require('@oclif/core/handle'))
+oclif.run().then(require("@oclif/core/flush")).catch(require("@oclif/core/handle"));

--- a/src/commands/bundle/create.ts
+++ b/src/commands/bundle/create.ts
@@ -16,6 +16,13 @@ export default class BundleCreate extends Command {
 
   public async run(): Promise<unknown> {
     const { args } = await this.parse(BundleCreate);
+
+    const resolvedDir = path.resolve(args.DIR);
+    const cwd = process.cwd();
+    if (resolvedDir === cwd || !resolvedDir.startsWith(cwd)) {
+      this.error("Error: Output directory must be a subdirectory of the current working directory");
+    }
+
     await generateManifest(args.DIR);
     const bundleName = normalizeBundleExtension(args.NAME);
     await compress(bundleName, args.DIR);


### PR DESCRIPTION
### Task
https://linear.app/earthfast/issue/ENG-161/enforce-cli-has-a-output-directory-path-thats-not