### PR TITLE
[ENG-254]CLI feedback bugfix

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "scripts": {
     "run": "export NODE_NO_WARNINGS=1 NODE_OPTIONS=--unhandled-rejections=none && npm run build && ./bin/run",
-    "dev": "export NODE_NO_WARNINGS=1 NODE_OPTIONS=--unhandled-rejections=none && npm run build && ./bin/dev",
+    "dev": "npm run build && ./bin/dev",
     "debug": "DEBUG=1 npm run build && ./bin/dev",
     "build": "rm -rf ./dist && tsc",
     "clean": "rm -rf ./dist",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "homepage": "https://earthfast.com",
   "license": "MIT",
   "scripts": {
-    "run": "export NODE_NO_WARNINGS=1 && npm run build && ./bin/run",
-    "dev": "export NODE_NO_WARNINGS=1 && npm run build && ./bin/dev",
+    "run": "export NODE_NO_WARNINGS=1 NODE_OPTIONS=--unhandled-rejections=none && npm run build && ./bin/run",
+    "dev": "export NODE_NO_WARNINGS=1 NODE_OPTIONS=--unhandled-rejections=none && npm run build && ./bin/dev",
     "debug": "DEBUG=1 npm run build && ./bin/dev",
     "build": "rm -rf ./dist && tsc",
     "clean": "rm -rf ./dist",
@@ -14,7 +14,7 @@
     "prepack": "npm run build && oclif manifest"
   },
   "bin": {
-    "earthfast": "export NODE_NO_WARNINGS=1 && ./bin/run"
+    "earthfast": "export NODE_NO_WARNINGS=1 NODE_OPTIONS=--unhandled-rejections=none && ./bin/run"
   },
   "files": [
     "/bin",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "prepack": "npm run build && oclif manifest"
   },
   "bin": {
-    "earthfast": "./bin/run"
+    "earthfast": "export NODE_NO_WARNINGS=1 && ./bin/run"
   },
   "files": [
     "/bin",

--- a/src/commands/admin/get.ts
+++ b/src/commands/admin/get.ts
@@ -2,8 +2,8 @@ import { BlockchainCommand } from "../../base";
 import { getContract, getProvider, pretty } from "../../helpers";
 
 export default class Get extends BlockchainCommand {
-  static description = "Make GET calls to EarthFast registry";
-  static examples = ['<%= config.bin %> usdc ""'];
+  static description = "Make GET calls to EarthFast contracts";
+  static examples = ["<%= config.bin %> EarthfastRegistry getUSDC"];
   static args = [
     {
       name: "contract",

--- a/src/commands/admin/get.ts
+++ b/src/commands/admin/get.ts
@@ -1,0 +1,39 @@
+import { BlockchainCommand } from "../../base";
+import { getContract, getProvider, pretty } from "../../helpers";
+
+export default class Get extends BlockchainCommand {
+  static description = "Make GET calls to EarthFast registry";
+  static examples = ['<%= config.bin %> usdc ""'];
+  static args = [
+    {
+      name: "contract",
+      required: true,
+      description: "Name of the contract to call eg 'EarthfastRegistry' or 'EarthfastNodes'",
+    },
+    {
+      name: "functionName",
+      required: true,
+      description: "Name of the registry function to call",
+    },
+    {
+      name: "params",
+      required: false,
+      description: "Comma-separated parameters for the function call",
+    },
+  ];
+
+  async run(): Promise<void> {
+    const { args, flags } = await this.parse(Get);
+
+    const params = args.params ? args.params.split(",") : [];
+    const functionName = args.functionName;
+    const contractName = args.contract;
+
+    const provider = await getProvider(flags.network, flags.rpc);
+    const contract = await getContract(flags.network, flags.abi, contractName, provider);
+
+    const output = await contract[functionName](...params);
+    this.log(pretty(output));
+    return output;
+  }
+}

--- a/src/commands/node/create.ts
+++ b/src/commands/node/create.ts
@@ -14,7 +14,8 @@ export default class NodeCreate extends TransactionCommand {
     { name: "ID", description: "The ID of the operator to own the nodes.", required: true },
     {
       name: "VALUES",
-      description: "The comma separated nodes data: HOST:REGION?:ENABLED?:PRICE?,...",
+      description: `The comma separated nodes data: HOST:REGION?:ENABLED?:PRICE?,...
+      Region options -> United States - 'us', Africa - 'af', Asia - 'as', Australia - 'au', Europe - 'eu', North America - 'na', South America - 'sa'`,
       required: true,
     },
     {
@@ -36,6 +37,9 @@ export default class NodeCreate extends TransactionCommand {
     if (defaultEnabled && !["true", "false"].includes(defaultEnabled)) {
       this.error(`Must specify true, false, or empty: ${args.DEFAULTS}.`);
     }
+    if (defaultRegion && !["us", "af", "as", "au", "eu", "na", "sa"].includes(defaultRegion)) {
+      this.error(`Must specify region from one of the following: 'us', 'af', 'as', 'au', 'eu', 'na', 'sa'.`);
+    }
 
     const records = await Promise.all(
       values.map(async (input) => {
@@ -45,11 +49,14 @@ export default class NodeCreate extends TransactionCommand {
         }
 
         const [host, region, enabled, price] = fields;
+        const regionFinal = region || defaultRegion;
         if (!host) {
           this.error(`Must specify node host: ${input}.`);
         }
-        if (!region && !defaultRegion) {
-          this.error(`Must specify region: ${input}.`);
+        if (!regionFinal || !["us", "af", "as", "au", "eu", "na", "sa"].includes(regionFinal)) {
+          this.error(
+            `Must specify region from one of the following: 'us', 'af', 'as', 'au', 'eu', 'na', 'sa'. Got: ${regionFinal}.`
+          );
         }
         if (enabled && !["true", "false"].includes(enabled)) {
           this.error(`Must specify true, false, or empty: ${input}.`);
@@ -57,7 +64,7 @@ export default class NodeCreate extends TransactionCommand {
 
         return {
           host,
-          region: region || defaultRegion,
+          region: regionFinal,
           disabled: enabled === "false" || (!enabled && defaultEnabled !== "true"),
           price: parseUSDC(price || defaultPrice || "0"),
         };

--- a/src/commands/project/list.ts
+++ b/src/commands/project/list.ts
@@ -1,23 +1,29 @@
 import { Flags } from "@oclif/core";
 import { Result } from "ethers/lib/utils";
 import { BlockchainCommand } from "../../base";
-import { formatProject, getAll, getContract, getProvider, parseAddress, pretty } from "../../helpers";
+import { formatNode, formatProject, getAll, getContract, getProvider, parseAddress, pretty } from "../../helpers";
 
 export default class ProjectList extends BlockchainCommand {
   static summary = "List projects on the EarthFast Network.";
   static examples = ["<%= config.bin %> <%= command.id %>"];
-  static usage = "<%= command.id %> [--owner ADDR] [--skip N] [--size N] [--page N]";
+  static usage = "<%= command.id %> [--owner ADDR] [--skip N] [--size N] [--page N] [--active] [--reservations]";
   static flags = {
     owner: Flags.string({ description: "Filter by owner address.", helpValue: "ADDR" }),
     skip: Flags.integer({ description: "The number of results to skip.", helpValue: "N", default: 0 }),
     size: Flags.integer({ description: "The number of results to list.", helpValue: "N", default: 100 }),
     page: Flags.integer({ description: "The contract call paging size.", helpValue: "N", default: 100 }),
+    reservations: Flags.boolean({ description: "Show reservations for each project", default: false }),
+    active: Flags.boolean({
+      description: "Filter projects to only show projects with active reservations",
+      default: false,
+    }),
   };
 
   public async run(): Promise<Record<string, unknown>[]> {
     const { flags } = await this.parse(ProjectList);
     const provider = await getProvider(flags.network, flags.rpc);
     const projects = await getContract(flags.network, flags.abi, "EarthfastProjects", provider);
+    const reservations = await getContract(flags.network, flags.abi, "EarthfastReservations", provider);
     const owner = parseAddress(flags.owner);
     const blockTag = await provider.getBlockNumber();
     let results: Result[] = await getAll(flags.page, async (i, n) => {
@@ -27,8 +33,27 @@ export default class ProjectList extends BlockchainCommand {
       results = results.filter((v) => v.owner.toLowerCase() === owner.toLowerCase());
     }
 
+    // If active is true, then reservations must also be true
+    if (flags.active && !flags.reservations) {
+      flags.reservations = true;
+    }
+
     const records = results.slice(flags.skip, flags.skip + flags.size);
-    const output = records.map((r) => formatProject(r));
+    let output = await Promise.all(
+      records.map(async (r) => {
+        const project = formatProject(r);
+        if (flags.reservations) {
+          const reservationResults: Result[] = await reservations.getReservations(r.id, 0, 1000, { blockTag });
+          project.reservations = reservationResults.map((r) => formatNode(r));
+        }
+        return project;
+      })
+    );
+
+    if (flags.active) {
+      output = output.filter((v) => (v.reservations as Result[]).length > 0);
+    }
+
     this.log(pretty(output));
     return output;
   }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -66,7 +66,7 @@ export const Permit: Record<string, Array<TypedDataField>> = {
 };
 
 export function pretty(value: unknown): string {
-  return typeof value === "string" ? value : inspect(value, { depth: 10 });
+  return typeof value === "string" ? value : inspect(value, { depth: 10, maxArrayLength: null });
 }
 
 export const parseUSDC = (value: string): BigNumber => parseUnits(value, 6);

--- a/src/keytarClient.ts
+++ b/src/keytarClient.ts
@@ -2,8 +2,33 @@
 // instead it should be imported dynamically in functions whenever necessary
 // the problem is it has a dependency on libsecret which is not
 // installed on ubuntu by default and this fails in CI eg CircleCI img/node
+import { execSync } from "child_process";
+import os from "os";
+
+function checkDependencies() {
+  if (os.platform() !== "linux") return;
+
+  try {
+    // Check for libsecret and gnome-keyring
+    execSync("ldconfig -p | grep libsecret-1.so.0", { stdio: "ignore", timeout: 500 });
+    execSync("which gnome-keyring-daemon", { stdio: "ignore", timeout: 500 });
+  } catch (error) {
+    console.warn(
+      `
+      Error: some required dependencies are not installed on your system required to manage the wallet.
+      Please install them using:
+      sudo apt-get install libsecret-1-dev gnome-keyring dbus-x11
+    `
+    );
+    // eslint-disable-next-line no-process-exit
+    process.exit(1);
+  }
+}
+
 class KeytarClient {
   async getKeytar() {
+    // check that keytar is installed if ubuntu
+    checkDependencies();
     return await import("keytar");
   }
 }


### PR DESCRIPTION
Lots of bugfixes here
- If on linux and libsecret is not installed, prompt dependencies to be installed
- Silence warnings/errors during key import
- Better checking for region codes
- New admin get command that can run arbitrary get commands across any contract eg `earthfast-cli EarthfastRegistry getUSDC` or `earthfast-cli EarthfastNodes getNodeCount 0x00...`
- Set JSON pretty print limit to null so it doesn't show "... n more items" when printing large arrays
- Ability to filter projects by those with active reservation and optionally show reservations for all projects